### PR TITLE
Re-enable the GitHub Actions CICD workflow

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -15,30 +15,31 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: make check
-  telemetry:
-    name: Telemetry
-    needs: checks
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/doitintl/docops/devcontainer:main
-    steps:
-      - uses: actions/checkout@v2
-      - run: make telemetry
-      - uses: crazy-max/ghaction-github-status@v2
-        with:
-          pages_threshold: major_outage
-      - uses: crazy-max/ghaction-github-pages@v2
-        if: success() && github.event_name != 'pull_request'
-        with:
-          target_branch: gh-pages
-          build_dir: gh-pages
-          keep_history: true
-          jekyll: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # TODO: Fix telemetry and reenable
+  # telemetry:
+  #   name: Telemetry
+  #   needs: checks
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: ghcr.io/doitintl/docops/devcontainer:main
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: make telemetry
+  #     - uses: crazy-max/ghaction-github-status@v2
+  #       with:
+  #         pages_threshold: major_outage
+  #     - uses: crazy-max/ghaction-github-pages@v2
+  #       if: success() && github.event_name != 'pull_request'
+  #       with:
+  #         target_branch: gh-pages
+  #         build_dir: gh-pages
+  #         keep_history: true
+  #         jekyll: false
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   notification:
     name: Notification
-    needs: telemetry
+    needs: checks
     if: always() && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -427,7 +427,7 @@ $(GH_PAGES_DIR)/index.html:
 # TODO: Include GitBook superQuery docs
 # TODO: Include Sphinx CMP docs
 
-GEN_ASSETS_LIST := $(BIN_DIR)/gen-assets-list.sh
+GEN_ASSETS_LIST = $(BIN_DIR)/gen-assets-list.sh
 
 $(GH_PAGES_DIR)/index.html: $(GH_PAGES_DIR)/assets.html
 .PHONY: $(GH_PAGES_DIR)/assets.html
@@ -442,6 +442,8 @@ $(GH_PAGES_DIR)/assets.html:
 
 # https://github.com/errata-ai/vale
 
+# TODO: Wrap this into the `vale.sh` script
+
 VALE_JSON = vale \
 	--config .vale.ini \
 	--minAlertLevel suggestion \
@@ -449,7 +451,7 @@ VALE_JSON = vale \
 	--no-wrap \
 	--no-exit
 
-VALE_JSON_RULE := $(FIND) --mode vale -print0 | xargs -0 $(VALE_JSON) >$@
+VALE_JSON_RULE = $(FIND) --mode vale --print0 | xargs -0 $(VALE_JSON) >$@
 
 $(GH_PAGES_DIR)/index.html: $(GH_PAGES_DIR)/vale.json
 .PHONY: $(GH_PAGES_DIR)/vale.json


### PR DESCRIPTION
Now that I have reworked the build system for a multi-instance docs setup and fixed all the issues that came up, it's time to put my work to the (literal) test.

This commit re-enables the old GitHub Actions CICD workflow. However, this time, the checks are run against:

- The live CMP public docs
- The live superQuery public docs
- My old Sphinx POC

I disabled the telemetry job because the telemetry rules still need some work, but they can wait for later.