### PR TITLE
Fix broken GitBook commit, configure link checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,33 +322,31 @@ vale:
 
 # https://github.com/smallhadroncollider/brok
 
-# BROK = brok --check-certs --only-failures
+BROK = brok --check-certs --only-failures
 
-# TODO: Keep cache file in Git
-
-# TODO: Check in new cache file during automated runs if the check passes
+# TODO: Keep cache file in Git to speed up CICD
 
 # all: brok
-# .PHONY: brok
-# brok:
-# 	$(call print-target)
-# 	$(FIND) -print0 | xargs -0 $(BROK)
+.PHONY: brok
+brok:
+	$(call print-target)
+	$(FIND) --mode md -print0 | xargs -0 $(BROK)
 
 # markdown-link-check
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 # https://github.com/tcort/markdown-link-check
 
-# MARKDOWN_LINK_CHECK = markdown-link-check \
-# 	--config .markdown-link-check.json \
-# 	--quiet \
-# 	--retry
+MARKDOWN_LINK_CHECK = markdown-link-check \
+	--config .markdown-link-check.json \
+	--quiet \
+	--retry
 
-# all: markdown-link-check
-# .PHONY: markdown-link-check
-# markdown-link-check:
-# 	$(call print-target)
-# 	$(FIND) --mode md --print0 | xargs -0 $(MARKDOWN_LINK_CHECK)
+all: markdown-link-check
+.PHONY: markdown-link-check
+markdown-link-check:
+	$(call print-target)
+	$(FIND) --mode md --print0 | xargs -0 $(MARKDOWN_LINK_CHECK)
 
 # rm-unused-assets
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/gitbook/cmp/flexsave/aws.md
+++ b/gitbook/cmp/flexsave/aws.md
@@ -6,9 +6,9 @@ description: >-
 
 # FlexSave for AWS
 
-FlexSave is your cloud co-pilot, dynamically maximizing your cloud-compute discounts for [Amazon Web Services](https://aws.amazon.com) (AWS) without any of the risks or limitations of long-term use commitments.
+FlexSave is your cloud co-pilot, dynamically maximizing your cloud-compute discounts for [Amazon Web Services][aws] (AWS) without any of the risks or limitations of long-term use commitments.
 
-In most cases, save [the equivalent of a 1-year commitment discount](overview.md#how-much-can-i-save-with-flexsave-for-amazon-web-services) on your cloud-compute spend with on-demand access to DoiT International's wholesale inventory of AWS [Savings Plans](https://https/aws.amazon.com/savingsplans/) (SPs) and AWS [EC2 Reserved Instances](https://https/aws.amazon.com/ec2/pricing/reserved-instances/) (RIs).
+In most cases, save [the equivalent of a 1-year commitment discount](overview.md#how-much-can-i-save) on your cloud-compute spend with on-demand access to DoiT International's wholesale inventory of AWS [Savings Plans][sps] (SPs) and AWS [EC2 Reserved Instances][ris] (RIs).
 
 {% hint style="info" %}
 See also:
@@ -82,14 +82,14 @@ Yes, you can. FlexSave works exclusively with your on-demand compute usage and e
 
 #### Can FlexSave provide discounts for on-demand capacity reservations?
 
-FlexSave only supports AWS regional reserved instances. Because AWS on-demand capacity reservations require zonal reserved instances, FlexSave does not provide capacity reservation discounts or discounts for [on-demand capacity reservations](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html).
+FlexSave only supports AWS regional reserved instances. Because AWS on-demand capacity reservations require zonal reserved instances, FlexSave does not provide capacity reservation discounts or discounts for [on-demand capacity reservations][capacity-reservations].
 
-FlexSave only supports AWS regional reserved instances. Because AWS on-demand capacity reservations require zonal reserved instances, FlexSave cannot provide discounts for [on-demand capacity reservations](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html).
+FlexSave only supports AWS regional reserved instances. Because AWS on-demand capacity reservations require zonal reserved instances, FlexSave cannot provide discounts for [on-demand capacity reservations][capacity-reservations].
 
 {% hint style="info" %}
 See also:
 
-* [AWS EC2 documentation: Regional and zonal reserved instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/reserved-instances-scope.html)
+* [AWS EC2 documentation: Regional and zonal reserved instances][regional-zonal]
 {% endhint %}
 
 #### I have a special pricing plan on my AWS account. Can I still use FlexSave, and will it impact my existing savings?
@@ -103,5 +103,11 @@ If you enabled FlexSave today, you might have to wait until the first week of ne
 ### Contact us
 
 {% hint style="info" %}
-If you have additional questions, please [contact our support team](../services/consulting-support/).
+If you have additional questions about FlexSave, please [contact our support team](../services/consulting-support/).
 {% endhint %}
+
+[aws]: https://aws.amazon.com/
+[capacity-reservations]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html
+[regional-zonal]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/reserved-instances-scope.html
+[ris]: https:/aws.amazon.com/ec2/pricing/reserved-instances/
+[sps]: https:/aws.amazon.com/savingsplans/

--- a/gitbook/cmp/flexsave/gcp.md
+++ b/gitbook/cmp/flexsave/gcp.md
@@ -6,9 +6,9 @@ description: >-
 
 # FlexSave for GCP
 
-FlexSave is your cloud co-pilot, dynamically maximizing your cloud-compute discounts for [Google Compute Platform](https://cloud.google.com) (GCP) without any of the risks or limitations of long-term use commitments.
+FlexSave is your cloud co-pilot, dynamically maximizing your cloud-compute discounts for [Google Compute Platform][gcp] (GCP) without any of the risks or limitations of long-term use commitments.
 
-In most cases, save [the equivalent of a 1-year commitment discount](overview.md#how-much-can-i-save-with-flexsave-for-google-cloud) on your cloud-compute spend with on-demand access to DoiT International's wholesale inventory of GCP [Committed Use Discounts](https://https/cloud.google.com/docs/cuds) (CUDs).
+In most cases, save [the equivalent of a 1-year commitment discount](overview.md#how-much-can-i-save) on your cloud-compute spend with on-demand access to DoiT International's wholesale inventory of GCP [Committed Use Discounts][cuds] (CUDs).
 
 {% hint style="info" %}
 See also:
@@ -22,7 +22,7 @@ See also:
 
 ### Supported regions and machine types
 
-FlexSave supports all GCP [regions](https://cloud.google.com/compute/docs/regions-zones) and [machine types](https://cloud.google.com/compute/docs/machine-types) supported by resource-based CUDs (except for GPU accelerators, i.e., `A2` instances). We don't support [commitments for GPUs or SSDs](https://cloud.google.com/compute/docs/instances/signing-up-committed-use-discounts#commitments\_for\_gpus\_and\_local\_ssd).
+FlexSave supports all GCP [regions](https://cloud.google.com/compute/docs/regions-zones) and [machine types](https://cloud.google.com/compute/docs/machine-types) supported by resource-based CUDs (except for GPU accelerators, i.e., `A2` instances). We don't support [commitments for GPUs or SSDs][gpus-ssds].
 
 ## Help
 
@@ -42,7 +42,7 @@ Absolutely. FlexSave works exclusively with your on-demand compute usage and exc
 
 #### Can I use FlexSave with _Google Kubernetes Engine_ (GKE)?
 
-FlexSave can provide CUD discounts for GKE nodes that use the [Google Compute Engine (GCE) pricing model](https://cloud.google.com/compute/docs/instances/signing-up-committed-use-discounts#restrictions). However, we cannot provide [CUD discounts for GKE Autopilot Mode](https://cloud.google.com/kubernetes-engine/cud).
+FlexSave can provide CUD discounts for GKE nodes that use the [Google Compute Engine (GCE) pricing model][gke-pricing]. However, we cannot provide [CUD discounts for GKE Autopilot Mode][gke-autopilot].
 
 #### I have a special pricing plan on my GCP account. Can I still use FlexSave, and will it impact my existing savings?
 
@@ -60,5 +60,12 @@ The commitments will apply committed use discounts across all eligible usage (al
 ### Contact us
 
 {% hint style="info" %}
-If you have additional questions, please [contact our support team](../services/consulting-support/).
+If you have additional questions about FlexSave, please [contact our support team](../services/consulting-support/).
 {% endhint %}
+
+[aws]: https://aws.amazon.com/
+[gke-pricing]: https://cloud.google.com/compute/docs/instances/signing-up-committed-use-discounts#restrictions
+[cuds]: https:/cloud.google.com/docs/cuds
+[gcp]: https://cloud.google.com/
+[gke-autopilot]: https://cloud.google.com/kubernetes-engine/cud
+[gpus-ssds]: https://cloud.google.com/compute/docs/instances/signing-up-committed-use-discounts#commitments_for_gpus_and_local_ssd

--- a/gitbook/cmp/flexsave/overview.md
+++ b/gitbook/cmp/flexsave/overview.md
@@ -6,9 +6,9 @@ description: >-
 
 # FlexSave overview
 
-FlexSave is your cloud co-pilot, dynamically maximizing your cloud-compute discounts for [Amazon Web Services](https://aws.amazon.com) (AWS) and [Google Compute Platform](https://cloud.google.com) (GCP) without any of the risks or limitations of long-term use commitments.
+FlexSave is your cloud co-pilot, dynamically maximizing your cloud-compute discounts for [Amazon Web Services][aws] (AWS) and [Google Compute Platform][gcp] (GCP) without any of the risks or limitations of long-term use commitments.
 
-In most cases, save [the equivalent of a 1-year commitment discount](overview.md#how-much-can-i-save) on your cloud-compute spend with on-demand access to DoiT International's wholesale inventory of AWS [Savings Plans](https://https/aws.amazon.com/savingsplans/) (SPs), AWS [EC2 Reserved Instances](https://https/aws.amazon.com/ec2/pricing/reserved-instances/) (RIs), and GCP [Committed Use Discounts](https://https/cloud.google.com/docs/cuds) (CUDs).
+In most cases, save [the equivalent of a 1-year commitment discount](#how-much-can-i-save) on your cloud-compute spend with on-demand access to DoiT International's wholesale inventory of AWS [Savings Plans][sps] (SPs), AWS [EC2 Reserved Instances][ris] (RIs), and GCP [Committed Use Discounts][cuds] (CUDs).
 
 {% hint style="info" %}
 See also:
@@ -20,8 +20,11 @@ See also:
 ## Benefits
 
 * _No commitment_ &mdash; AWS and GCP provide cloud-compute discounts (SPs, RIs, and CUDs) with mandatory commitment periods lasting one year or more. FlexSave provides the same cloud-compute discounts with no commitments.
+
 * _No risk_ &mdash; FlexSave provides on-demand access to DoiT International's wholesale inventory of SPs, RIs, and CUDs. We handle capacity planning and bear the risk of underutilization, meaning you don't have to.
+
 * _Zero cost_ &mdash; FlexSave costs nothing, there are no hidden fees, and _you are guaranteed to save money_. We optimize our bulk purchasing, so, in most cases, we can afford to pass on the equivalent of a 1-year commitment discount for any SPs, RIs, and CUDs in our wholesale inventory.
+
 * _Easy to use_ &mdash; FlexSave runs on auto-pilot, continually applying the optimum cost-saving strategy to your account. You can enable or disable FlexSave whenever you like.
 
 ## How it works
@@ -30,7 +33,7 @@ FlexSave uses your GCP and AWS billing data to track your on-demand resource uti
 
 FlexSave will attach the ideal blend of DoiT International's wholesale SPs, RIs, and CUDs to your billing account. As your resource utilization changes, FlexSave will continually readjust the configuration of attached SPs, RIs, and CUDs to maximize your potential savings.
 
-We will automatically convert your FlexSave savings to account credits and [deduct them from your monthly invoice](overview.md#invoicing).
+We will automatically convert your FlexSave savings to account credits and [deduct them from your monthly invoice](#invoicing).
 
 ## Start saving
 
@@ -65,7 +68,8 @@ Within the CMP, select _Savings_ from the top menu bar, then select _FlexSave_ f
 In the example screenshot above, FlexSave for GCP has only been active for one and a half months and has already saved the customer a total of $248,145 on their on-demand cloud-compute spend so far.
 {% endhint %}
 
-In the top-right hand corner of the screen, a _Time range_ drop-down menu allows you to select the time range you want to view. Above the bar chart, the CMP displays three essential statistics for the specified time range:
+In the top-right hand corner of the screen, a _Time range_ drop-down menu allows you to select the time range you want to view.
+Above the bar chart, the CMP displays three essential statistics for the specified time range:
 
 * _Time range savings rate_ &mdash; The effective discount applied to your on-demand spend
 * _Time range savings_ &mdash; Your savings as a result of using FlexSave
@@ -91,12 +95,12 @@ Because _Units_ is always set to -1 (indicating a credit), the FlexSave _Price P
 
 Here's an abbreviated example:
 
-| Description      | Units |         PPU |        Price |
-| ---------------- | ----: | ----------: | -----------: |
-| Google Cloud     |     1 | $574,813.82 |  $574,813.82 |
-| FlexSave Savings |    -1 | $206,967.51 | -$206,967.51 |
-|                  |       |             |              |
-| Total            |       |             |  $206,967.51 |
+| Description         | Units |         PPU |        Price |
+| ------------------- | ----: | ----------: | -----------: |
+| Google Cloud        |     1 | $574,813.82 |  $574,813.82 |
+| FlexSave Savings    |    -1 | $206,967.51 | -$206,967.51 |
+|                     |       |             |              |
+| Total               |       |             |  $206,967.51 |
 
 ### FAQs
 
@@ -109,15 +113,9 @@ For general platform-specific information, see:
 * [FlexSave for GCP: FAQs](gcp.md#faqs)
 {% endhint %}
 
-#### How much can I save with FlexSave for Amazon Web Services?
+#### How much can I save?
 
-Customers on _shared payer accounts_ (e.g. without dedicated AWS organization) and in most cases, will be saving the equivalent to (or higher than) the applicable [AWS Convertible Reserved Instance 1-year Full Upfront](https://aws.amazon.com/ec2/pricing/reserved-instances/pricing/).
-
-Customers on _dedicated payer accounts_ (e.g. with dedicated AWS organization) and in most cases, will be saving the equivalent to (or higher than) the applicable [AWS Convertible Reserved Instance 1-year No Upfront](https://aws.amazon.com/ec2/pricing/reserved-instances/pricing/).
-
-#### How much can I save with FlexSave for Google Cloud?
-
-You can expect to save as much as (or higher than) the applicable [1-year Google Committed Use Discount](https://cloud.google.com/compute/vm-instance-pricing#committed\_use).
+In most cases, your savings will be equivalent to (or higher than) the applicable [AWS Convertible Reserved Instance 1-year Full Upfront][ri-pricing] or [1-year Google Committed Use Discount][cud-pricing].
 
 #### How is using FlexSave better than purchasing discounts directly from AWS or GCP?
 
@@ -135,9 +133,19 @@ FlexSave will be unavailable if either of the following is true:
 If we are still importing and processing your billing data, you can instead select the _NOTIFY ME_ button to receive an update when FlexSave is available.
 
 {% hint style="warning" %}
-At this time, we only support FlexSave for AWS customers with billing accounts [consolidated](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/consolidated-billing.html) with the DoiT International billing organization.
+At this time, we only support FlexSave for AWS customers with billing accounts [consolidated][consolidated] with the DoiT International billing organization.
 {% endhint %}
 
 #### Can I turn off FlexSave?
 
 You can disable of FlexSave at any time. If you want to disable FlexSave, please [create a new request](../services/consulting-support/#create-a-new-request) for our support team.
+
+[aws]: https://aws.amazon.com/
+[consolidated]: https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/consolidated-billing.html
+[cud-pricing]: https://cloud.google.com/compute/vm-instance-pricing#committed_use
+[cuds]: https:/cloud.google.com/docs/cuds
+[gcp]: https://cloud.google.com/
+[reseller]: https://partners.amazonaws.com/partners/001E000001HPlIAIA1/
+[ri-pricing]: https://aws.amazon.com/ec2/pricing/reserved-instances/pricing/
+[ris]: https:/aws.amazon.com/ec2/pricing/reserved-instances/
+[sps]: https:/aws.amazon.com/savingsplans/

--- a/gitbook/cmp/services/consulting-support/README.md
+++ b/gitbook/cmp/services/consulting-support/README.md
@@ -9,14 +9,16 @@ DoiT International provides unlimited consulting and support for Amazon Web Serv
 As a customer, you are not limited to any number of tickets or by how much time DoiT International invests in supporting you as a client.
 
 {% hint style="info" %}
+
 For more information about the services we offer, please visit the [Services](https://www.doit-intl.com/services/) page on our main website.
+
 {% endhint %}
 
 ## View tickets
 
 From within the CMP, select _Services_ from the top navigation bar, then select _Consulting and support_:
 
-![A screenshot showing the Consulting and support page](../../.gitbook/assets/cmp-services-consulting-support.png)
+![A screenshot showing the _Consulting and support_ page](../../.gitbook/assets/cmp-services-consulting-support.png)
 
 By default, the _Consulting and support_ page lists all of your current request tickets. You can use the _Filter tickets_ input field to filter the list of tickets.
 
@@ -25,13 +27,17 @@ If there are any current [cloud incidents](cloud-incidents.md), they will be dis
 You can use the gear menu in the top right-hand corner of the page to [enable ticket sharing](ticket-sharing.md) or [manage the default email CC](manage-default-email-cc.md).
 
 {% hint style="info" %}
+
 When you first visit the _Consulting and support_ page, your browser may prompt you to allow notifications. If you select _Allow_, the CMP will notify you whenever one of your tickets (or a ticket you are CCed on) is updated.
+
 {% endhint %}
 
 ## Create a new request
 
 {% hint style="info" %}
+
 For simple questions and trivial requests, you can skip the ticket creation process (below) and, instead, send a message to your [shared Slack channel](shared-slack-channel.md) for a quick response from our engineering or support staff.
+
 {% endhint %}
 
 Select the _NEW REQUEST_ button (shown in the previous screenshot) to create a new consulting or support request.
@@ -40,22 +46,28 @@ After selecting _NEW REQUEST_, the CMP will take you through the steps of creati
 
 1. Select the _Cloud Platform_, _Product_, and _Resource_ so that we can route your ticket to the most appropriate engineer.
 
-{% hint style="warning" %}
-The CMP will display a list of any current [incidents](cloud-incidents.md) related to the cloud platform you select during this step.
+   {% hint style="warning" %}
 
-If one of the current incidents appears to be related to your request, you may still open a ticket with DoiT International. However, we are likely already working with the cloud vendor to address the issue.
-{% endhint %}
+   The CMP will display a list of any current [incidents](cloud-incidents.md) related to the cloud platform you select during this step.
 
-1. Select the severity of your request. Each severity level corresponds with a target response time:
+   If one of the current incidents appears to be related to your request, you may still open a ticket with DoiT International. However, likely, we are already working with the cloud vendor to address the issue.
+
+   {% endhint %}
+
+2. Select the severity of your request. Each severity level corresponds with a target response time:
+
    * General Guidance &mdash; Four hours
    * System Impaired &mdash; Two hours
    * Production System Impaired &mdash; One hour
    * Production System Down &mdash; 30 minutes
-2. Write a descriptive subject, add any additional CCs to the ticket, and provide a complete description of your request.
 
-{% hint style="info" %}
-In some cases, the CMP may automatically add your cloud vendor representative (e.g., account manager or customer engineer) to the list of _Additional CCs_. Please feel free to remove their email addresses if you do not wish to copy them on your ticket.
-{% endhint %}
+3. Write a descriptive subject, add any additional CCs to the ticket, and provide a complete description of your request.
+
+   {% hint style="info" %}
+
+   In some cases, the CMP may automatically add your cloud vendor representative (e.g., account manager or customer engineer) to the list of _Additional CCs_. Please feel free to remove their email addresses if you do not wish to copy them on your ticket.
+
+   {% endhint %}
 
 At any point, select the _BACK_ button to return to a previous step.
 

--- a/sphinx/cmp/CONTRIBUTING.md
+++ b/sphinx/cmp/CONTRIBUTING.md
@@ -17,11 +17,11 @@ Please feel free to [create an issue][issues] if you would like to:
 ## Create a pull request
 
 The documentation project is built with [Sphinx][sphinx]. The
-[reStructuredText][rst] (RST) source files are located in the [docs][docs]
+[reStructuredText][rst] (RST) source files are located in the [src][src]
 directory. If you would like to make changes directly, please feel free to
 [fork this repository][fork] and [create a pull request][pr].
 
-[docs]: https://github.com/doitintl/sphinx-docs-cmp/docs
+[src]: https://github.com/doitintl/docs/tree/main/sphinx/cmp/src
 [doit-org]: https://github.com/doitintl/
 [fork]: https://docs.github.com/en/get-started/quickstart/fork-a-repo
 [issues]: https://github.com/doitintl/sphinx-docs-cmp/issues

--- a/sphinx/cmp/README.md
+++ b/sphinx/cmp/README.md
@@ -45,4 +45,4 @@ Until this version of the documentation goes live, any substantial changes to th
 This project is primarily maintained by [DoiT International][doit-org] staff. However, we do welcome community contributions! Please read the [contribution documentation][contributing] for more information.
 
 [doit-org]: https://github.com/doitintl/
-[contributing]: https://github.com/doitintl/sphinx-docs-cmp/CONTRIBUTING/md
+[contributing]: https://github.com/doitintl/docs/tree/main/CONTRIBUTING.md


### PR DESCRIPTION
The last commit from GitBook inexplicably broke a few things, most notably reverting some of the text to an older version.

This commit fixes the GitBook errors.

Additionally, I have re-enabled the `markdown-link-check` target, fixed some issues with the Sphinx import, and enabled the optional (i.e., not run during CICD) `brok` target.